### PR TITLE
Fix error 'is undefined'

### DIFF
--- a/src/requests.js
+++ b/src/requests.js
@@ -466,10 +466,13 @@ export function changesetCheckRequest(auth, endpoint, changesetId) {
         if (err) {
           throw new RequestException('Changeset check request failed');
         }
-
-        const isOpened = xml
-          .getElementsByTagName('changeset')[0]
-          .getAttribute('open');
+        
+        let isOpened = 'false';
+        const changeset = xml.getElementsByTagName('changeset')[0];
+        
+        if (changeset) {  
+          isOpened = changeset.getAttribute('open');
+        }
 
         if (isOpened === 'false') {
           return reject(err);


### PR DESCRIPTION
I don't know why but in Pic4Review I encounter an error that the following code:
`xml.getElementsByTagName('changeset')[0]`
is returning an undefined object. so the function call:
`getAttribute('open')`
cause the JS runtime to crash.

I'm really not sure, that my patch is gonna fix 'the real' issue. So please, take time to track down this bug.