### PR TITLE
Update badge: use branch develop for coverage status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub Tag](https://img.shields.io/github/v/tag/osmlab/osm-request)](https://github.com/osmlab/osm-request/tags)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/osmlab/osm-request/build-tests-coverage.yml)](https://github.com/osmlab/osm-request/actions/workflows/build-tests-coverage.yml)
-[![Coverage Status](https://coveralls.io/repos/github/osmlab/osm-request/badge.svg)](https://coveralls.io/github/osmlab/osm-request)
+[![Coverage Status](https://coveralls.io/repos/github/osmlab/osm-request/badge.svg?branch=develop)](https://coveralls.io/github/osmlab/osm-request?branch=develop)
 
 # OSM Request
 


### PR DESCRIPTION
seems like, we should reference branch develop to have the latest coveralls scan (otherwise, we have the coverage of branch main)